### PR TITLE
Accepting query argument 'v' to dump the refreshed token as a json doc.

### DIFF
--- a/api_explorer/views/views.py
+++ b/api_explorer/views/views.py
@@ -68,6 +68,8 @@ def refresh_tokens():
     else:
         session['oauth_token'] = token
         db_ = OAuthDB()
+        if request.args.get('v', default='html') == 'json':
+            return jsonify(token)
         db_.update_oauth(token)
         return render_template(
             'pages/authorization.html',


### PR DESCRIPTION
This small modification will accept calls like `https://<fqdn>/refresh_tokens?v=json` and dump the just refreshed token as a json document instead of rendering the HTML template.